### PR TITLE
Increase restart limit to match intellij-elixir test rate

### DIFF
--- a/lib/intellij_elixir/supervisor.ex
+++ b/lib/intellij_elixir/supervisor.ex
@@ -11,7 +11,10 @@ defmodule IntellijElixir.Supervisor do
     children = [
       worker(@quoter_module, [[], [name: @quoter_module]])
     ]
-    
-    supervise(children, strategy: :one_for_one)
+
+    # Tuned based on intellij-elixir processing 1019 tests in 4 seconds, which is 254.75 tests per second.  Although
+    # most tests are not expected to cause exits, just tuning to the test rate is less coupled than tuning to the
+    # expected exit rate as expected exit is a new assertion for testing.
+    supervise(children, max_restarts: 1000, max_seconds: 4, strategy: :one_for_one)
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule IntellijElixir.Mixfile do
 
   def project do
     [app: :intellij_elixir,
-     version: "0.1.0",
+     version: "0.1.1",
      elixir: "~> 1.0",
      deps: deps]
   end


### PR DESCRIPTION
Fixes #3 

Change from the default 3 restarts per 5 seconds to 1000 restarts per 4 seconds to approximate the 1019 tests per 4 seconds currently in intellij-elixir.
