### PR TITLE
Switch from exrm to distillery for Elixir 1.5 compatibility

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,8 @@
+engines:
+  credo:
+    enabled: true
+    channel: beta
+ratings:
+  paths:
+  - "**.ex"
+  - "**.exs"

--- a/.credo.exs
+++ b/.credo.exs
@@ -1,0 +1,21 @@
+%{
+  # You can have as many configs as you like in the `configs:` field.
+  configs: [
+    %{
+      # Run any config using `mix credo -C <name>`. If no config name is given
+      # "default" is used.
+      name: "default",
+      # These are the files included in the analysis:
+      files: %{
+        # You can give explicit globs or simply directories.
+        # In the latter case `**/*.{ex,exs}` will be used.
+        included: ["lib/"],
+        excluded: [~r"/_build/", ~r"/deps/"]
+      },
+      strict: true,
+      checks: [
+        {Credo.Check.Readability.MaxLineLength, priority: :low, max_length: 120},
+      ]
+    }
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # IDEA ignores - see https://intellij-support.jetbrains.com/entries/23393067
 /.idea/workspace.xml
+/.idea/markdown*
 # mix new ignores
 /_build
 /deps

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,5 @@
 # IDEA ignores - see https://intellij-support.jetbrains.com/entries/23393067
 /.idea/workspace.xml
-# exrm output
-/rel
 # mix new ignores
 /_build
 /deps

--- a/.idea/.name
+++ b/.idea/.name
@@ -1,1 +1,0 @@
-intellij_elixir

--- a/.idea/copyright/profiles_settings.xml
+++ b/.idea/copyright/profiles_settings.xml
@@ -1,3 +1,0 @@
-<component name="CopyrightManager">
-  <settings default="" />
-</component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,16 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="ProjectLevelVcsManager" settingsEditedManually="false">
-    <OptionsSetting value="true" id="Add" />
-    <OptionsSetting value="true" id="Remove" />
-    <OptionsSetting value="true" id="Checkout" />
-    <OptionsSetting value="true" id="Update" />
-    <OptionsSetting value="true" id="Status" />
-    <OptionsSetting value="true" id="Edit" />
-    <ConfirmationsSetting value="0" id="Add" />
-    <ConfirmationsSetting value="0" id="Remove" />
+  <component name="PDMPlugin">
+    <option name="skipTestSources" value="false" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_6" default="true" assert-keyword="true" jdk-15="true">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_3" default="true" project-jdk-name="Elixir 1.3.4" project-jdk-type="Elixir SDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
   <component name="masterDetails">

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,25 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="PDMPlugin">
-    <option name="skipTestSources" value="false" />
+  <component name="EmacsSettings">
+    <option name="emacsPath" value="/usr/bin/emacs" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_3" default="true" project-jdk-name="Elixir 1.3.4" project-jdk-type="Elixir SDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_5" project-jdk-name="Elixir 1.5.2" project-jdk-type="Elixir SDK">
     <output url="file://$PROJECT_DIR$/out" />
-  </component>
-  <component name="masterDetails">
-    <states>
-      <state key="ProjectJDKs.UI">
-        <settings>
-          <last-edited>1.6</last-edited>
-          <splitter-proportions>
-            <option name="proportions">
-              <list>
-                <option value="0.2" />
-              </list>
-            </option>
-          </splitter-proportions>
-        </settings>
-      </state>
-    </states>
   </component>
 </project>

--- a/.idea/mix.xml
+++ b/.idea/mix.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="ElixirCompilerOptions">
-    <useMixCompiler>true</useMixCompiler>
+  <component name="MixSettings">
+    <mixPath>/usr/local/bin/mix</mixPath>
   </component>
 </project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -2,7 +2,7 @@
 <project version="4">
   <component name="ProjectModuleManager">
     <modules>
-      <module fileurl="file://$PROJECT_DIR$/intellij_elixir.iml" filepath="$PROJECT_DIR$/intellij_elixir.iml" />
+      <module fileurl="file://$PROJECT_DIR$/intellijelixir.iml" filepath="$PROJECT_DIR$/intellijelixir.iml" />
     </modules>
   </component>
 </project>

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,6 @@ matrix:
       otp_release: 19.3
     - elixir: 1.3.4
       otp_release: 19.3
-    - elixir: 1.2.6
-      otp_release: 18.3
-    - elixir: 1.1.1
-      otp_release: 18.3
 sudo: false
 script:
 - mix test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,9 @@
+cache:
+  directories:
+    - _build
+    - deps
 language: elixir
 sudo: false
+script:
+- mix test
+- mix dialyzer

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,12 @@ cache:
 language: elixir
 matrix:
   include:
-    - elixir: 1.4.2
-      otp_release: 19.2
+    - elixir: 1.5.2
+      otp_release: 20.1
+    - elixir: 1.4.5
+      otp_release: 19.3
     - elixir: 1.3.4
-      otp_release: 19.2
+      otp_release: 19.3
     - elixir: 1.2.6
       otp_release: 18.3
     - elixir: 1.1.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,16 @@ cache:
     - _build
     - deps
 language: elixir
+matrix:
+  include:
+    - elixir: 1.4.2
+      otp_release: 19.2
+    - elixir: 1.3.4
+      otp_release: 19.2
+    - elixir: 1.2.6
+      otp_release: 18.3
+    - elixir: 1.1.1
+      otp_release: 18.3
 sudo: false
 script:
 - mix test

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 IntellijElixir
 ==============
 
+[![Build Status](https://travis-ci.org/KronicDeth/intellij_elixir.svg?branch=master)](https://travis-ci.org/KronicDeth/intellij_elixir)
 [![Code Climate](https://codeclimate.com/github/KronicDeth/intellij_elixir/badges/gpa.svg)](https://codeclimate.com/github/KronicDeth/intellij_elixir)
 
 Elixir helpers for [intellj-elixir](https://github.com/KronicDeth/intellij-elixir),

--- a/README.md
+++ b/README.md
@@ -5,6 +5,13 @@ Elixir helpers for [intellj-elixir](https://github.com/KronicDeth/intellij-elixi
 the [Elixir](http://elixir-lang.org) plugin for [JetBrains](https://www.jetbrains.com)
 IDEs.
 
+# Building Release
+
+To build the release for production, set both the `MIX_ENV` and
+distillery environment to `prod`
+
+`MIX_ENV=prod mix release --env=prod`
+
 # Using with intellij-elixir tests
 
 [intellij-elixir](https://github.com/KronicDeth/intellij-elixir)'s
@@ -12,8 +19,8 @@ IDEs.
 to verify that intellij-elixir's parsed and quoted form match's Elixir's native
 quoted form from `Code.string_to_quoted`.  IntellijElixir must be running
 on node name `intellij_elixir` for intellij-elixir's tests to find it, so start
-IntellijElixir app like so
+IntellijElixir release like so
 
 ```
-iex --sname intellij_elixir -S mix
+_build/prod/rel/intellij_elixir/bin/intellij_elixir start
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 IntellijElixir
 ==============
 
+[![Code Climate](https://codeclimate.com/github/KronicDeth/intellij_elixir/badges/gpa.svg)](https://codeclimate.com/github/KronicDeth/intellij_elixir)
+
 Elixir helpers for [intellj-elixir](https://github.com/KronicDeth/intellij-elixir),
 the [Elixir](http://elixir-lang.org) plugin for [JetBrains](https://www.jetbrains.com)
 IDEs.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,5 +1,9 @@
 # Upgrading
 
+## v1.0.0
+
+If upgrading from v0.1.1 or earlier, you'll need to change the path to start the release from `rel/intellij_elixir/bin/intellij_elixir` to `_build/prod/rel/intellij_elixir/bin/intellij_elixir`.
+
 ## v0.1.0
 
 If upgrading from v0.0.1, you'll now need to perform `GenServer.call IntellijElixir.Quoter, code` instead of

--- a/intellij_elixir.iml
+++ b/intellij_elixir.iml
@@ -2,9 +2,7 @@
 <module type="WEB_MODULE" version="4">
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
-    <content url="file://$MODULE_DIR$">
-      <excludeFolder url="file://$MODULE_DIR$/rel" />
-    </content>
+    <content url="file://$MODULE_DIR$" />
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>

--- a/intellijelixir.iml
+++ b/intellijelixir.iml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="ELIXIR_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <output url="file://$MODULE_DIR$/_build/dev/lib/intellijelixir/ebin" />
+    <output-test url="file://$MODULE_DIR$/_build/test/lib/intellijelixir/ebin" />
+    <exclude-output />
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/lib" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/test" isTestSource="true" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/lib/intellij_elixir.ex
+++ b/lib/intellij_elixir.ex
@@ -1,6 +1,11 @@
 defmodule IntellijElixir do
+  @moduledoc """
+  Exposed `GenServer`, `IntellijElixir.Quoter` that can quote code using `Code.string_to_quoted/1`
+  """
+
   use Application
 
+  @spec start(Application.start_type, []) :: {:ok, pid}
   def start(_type, _args) do
     IntellijElixir.Supervisor.start_link
   end

--- a/lib/intellij_elixir/quoter.ex
+++ b/lib/intellij_elixir/quoter.ex
@@ -1,10 +1,23 @@
 defmodule IntellijElixir.Quoter do
+  @moduledoc """
+  `Code.string_to_quoted/1` server
+  """
   use GenServer
 
+  # Types
+
+  @type t :: []
+  @type line :: non_neg_integer
+  @type error :: any
+  @type token :: binary
+
+  @spec start_link(t) :: {:ok, pid}
+  @spec start_link(t, [name: atom]) :: {:ok, pid}
   def start_link(args, opts \\ []) do
     GenServer.start_link(__MODULE__, args, opts)
   end
 
+  @spec handle_call(String.t, GenServer.from, t) :: {:reply, {:ok, Macro.t} | {:error, {line, error, token}}, t}
   def handle_call(code, _from, state) do
     {:reply, Code.string_to_quoted(code), state}
   end

--- a/lib/intellij_elixir/supervisor.ex
+++ b/lib/intellij_elixir/supervisor.ex
@@ -12,7 +12,7 @@ defmodule IntellijElixir.Supervisor do
 
   @quoter_module IntellijElixir.Quoter
 
-  @spec init(:ok) :: {:ok, tuple}
+  @spec init(:ok) :: {:ok, {{:one_for_one, 1000, 4}, [Supervisor.Spec.spec]}}
   def init(:ok) do
     children = [
       worker(@quoter_module, [[], [name: @quoter_module]])

--- a/lib/intellij_elixir/supervisor.ex
+++ b/lib/intellij_elixir/supervisor.ex
@@ -1,12 +1,18 @@
 defmodule IntellijElixir.Supervisor do
+  @moduledoc """
+  Supervises `IntellijElixir.Quoter`
+  """
+
   use Supervisor
 
+  @spec start_link :: {:ok, pid}
   def start_link do
     Supervisor.start_link(__MODULE__, :ok)
   end
 
   @quoter_module IntellijElixir.Quoter
 
+  @spec init(:ok) :: {:ok, tuple}
   def init(:ok) do
     children = [
       worker(@quoter_module, [[], [name: @quoter_module]])

--- a/mix.exs
+++ b/mix.exs
@@ -2,10 +2,15 @@ defmodule IntellijElixir.Mixfile do
   use Mix.Project
 
   def project do
-    [app: :intellij_elixir,
-     version: "1.0.0",
-     elixir: "~> 1.0",
-     deps: deps]
+    [
+      app: :intellij_elixir,
+      deps: deps(),
+      elixir: "~> 1.0",
+      preferred_cli_env: [
+        "credo": :test
+      ],
+      version: "1.0.0"
+    ]
   end
 
   # Configuration for the OTP application
@@ -26,6 +31,9 @@ defmodule IntellijElixir.Mixfile do
   #
   # Type `mix help deps` for more examples and options
   defp deps do
-    [{:distillery, "~> 1.1"}]
+    [
+      {:credo, "~> 0.6.1", only: :test},
+      {:distillery, "~> 1.1"}
+    ]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule IntellijElixir.Mixfile do
 
   def project do
     [app: :intellij_elixir,
-     version: "0.1.1",
+     version: "1.0.0",
      elixir: "~> 1.0",
      deps: deps]
   end
@@ -26,6 +26,6 @@ defmodule IntellijElixir.Mixfile do
   #
   # Type `mix help deps` for more examples and options
   defp deps do
-    [{:exrm, "~> 0.14.16"}]
+    [{:distillery, "~> 1.1"}]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,8 @@ defmodule IntellijElixir.Mixfile do
       deps: deps(),
       elixir: "~> 1.0",
       preferred_cli_env: [
-        "credo": :test
+        "credo": :test,
+        "dialyzer": :test
       ],
       version: "1.0.0"
     ]
@@ -33,6 +34,7 @@ defmodule IntellijElixir.Mixfile do
   defp deps do
     [
       {:credo, "~> 0.6.1", only: :test},
+      {:dialyxir, "~> 0.5", only: :test, runtime: false},
       {:distillery, "~> 1.1"}
     ]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -35,7 +35,7 @@ defmodule IntellijElixir.Mixfile do
     [
       {:credo, "~> 0.6.1", only: :test},
       {:dialyxir, "~> 0.5", only: :test, runtime: false},
-      {:distillery, "~> 1.1"}
+      {:distillery, "~> 1.4", runtime: false}
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,3 +1,5 @@
-%{"conform": {:hex, :conform, "0.11.0", "fe5a68ab8533b53b4a463aa2ee71c622bea19b86e0183b8d34c23c6b8ed17dc7", [:mix], []},
+%{"bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], []},
+  "conform": {:hex, :conform, "0.11.0", "fe5a68ab8533b53b4a463aa2ee71c622bea19b86e0183b8d34c23c6b8ed17dc7", [:mix], []},
+  "credo": {:hex, :credo, "0.6.1", "a941e2591bd2bd2055dc92b810c174650b40b8290459c89a835af9d59ac4a5f8", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, optional: false]}]},
   "distillery": {:hex, :distillery, "1.1.2", "4cf32ecc70ca7eecca9e52e111edf320bd78011050825863cd8bc7ffee686c5d", [:mix], []},
   "exrm": {:hex, :exrm, "0.14.16", "8a222b1daeb9aa29ffcbb8d98980de65fb7f159c503b102e661a933d8ce01494", [:mix], [{:conform, "~> 0.11.0", [hex: :conform, optional: false]}]}}

--- a/mix.lock
+++ b/mix.lock
@@ -2,5 +2,5 @@
   "conform": {:hex, :conform, "0.11.0", "fe5a68ab8533b53b4a463aa2ee71c622bea19b86e0183b8d34c23c6b8ed17dc7", [:mix], []},
   "credo": {:hex, :credo, "0.6.1", "a941e2591bd2bd2055dc92b810c174650b40b8290459c89a835af9d59ac4a5f8", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, optional: false]}]},
   "dialyxir": {:hex, :dialyxir, "0.5.0", "5bc543f9c28ecd51b99cc1a685a3c2a1a93216990347f259406a910cf048d1d7", [:mix], []},
-  "distillery": {:hex, :distillery, "1.1.2", "4cf32ecc70ca7eecca9e52e111edf320bd78011050825863cd8bc7ffee686c5d", [:mix], []},
+  "distillery": {:hex, :distillery, "1.4.1", "546d851bf27ae8fe0727e10e4fc4e146ad836eecee138263a60431e688044ed3", [:mix], [], "hexpm"},
   "exrm": {:hex, :exrm, "0.14.16", "8a222b1daeb9aa29ffcbb8d98980de65fb7f159c503b102e661a933d8ce01494", [:mix], [{:conform, "~> 0.11.0", [hex: :conform, optional: false]}]}}

--- a/mix.lock
+++ b/mix.lock
@@ -1,2 +1,3 @@
-%{"conform": {:hex, :conform, "0.11.0"},
-  "exrm": {:hex, :exrm, "0.14.16"}}
+%{"conform": {:hex, :conform, "0.11.0", "fe5a68ab8533b53b4a463aa2ee71c622bea19b86e0183b8d34c23c6b8ed17dc7", [:mix], []},
+  "distillery": {:hex, :distillery, "1.1.2", "4cf32ecc70ca7eecca9e52e111edf320bd78011050825863cd8bc7ffee686c5d", [:mix], []},
+  "exrm": {:hex, :exrm, "0.14.16", "8a222b1daeb9aa29ffcbb8d98980de65fb7f159c503b102e661a933d8ce01494", [:mix], [{:conform, "~> 0.11.0", [hex: :conform, optional: false]}]}}

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,6 @@
 %{"bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], []},
   "conform": {:hex, :conform, "0.11.0", "fe5a68ab8533b53b4a463aa2ee71c622bea19b86e0183b8d34c23c6b8ed17dc7", [:mix], []},
   "credo": {:hex, :credo, "0.6.1", "a941e2591bd2bd2055dc92b810c174650b40b8290459c89a835af9d59ac4a5f8", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, optional: false]}]},
+  "dialyxir": {:hex, :dialyxir, "0.5.0", "5bc543f9c28ecd51b99cc1a685a3c2a1a93216990347f259406a910cf048d1d7", [:mix], []},
   "distillery": {:hex, :distillery, "1.1.2", "4cf32ecc70ca7eecca9e52e111edf320bd78011050825863cd8bc7ffee686c5d", [:mix], []},
   "exrm": {:hex, :exrm, "0.14.16", "8a222b1daeb9aa29ffcbb8d98980de65fb7f159c503b102e661a933d8ce01494", [:mix], [{:conform, "~> 0.11.0", [hex: :conform, optional: false]}]}}

--- a/rel/config.exs
+++ b/rel/config.exs
@@ -1,0 +1,44 @@
+# Import all plugins from `rel/plugins`
+# They can then be used by adding `plugin MyPlugin` to
+# either an environment, or release definition, where
+# `MyPlugin` is the name of the plugin module.
+Path.join(["rel", "plugins", "*.exs"])
+|> Path.wildcard()
+|> Enum.map(&Code.eval_file(&1))
+
+use Mix.Releases.Config,
+    # This sets the default release built by `mix release`
+    default_release: :default,
+    # This sets the default environment used by `mix release`
+    default_environment: Mix.env()
+
+# For a full list of config options for both releases
+# and environments, visit https://hexdocs.pm/distillery/configuration.html
+
+
+# You may define one or more environments in this file,
+# an environment's settings will override those of a release
+# when building in that environment, this combination of release
+# and environment configuration is called a profile
+
+environment :dev do
+  set dev_mode: true
+  set include_erts: false
+  set cookie: :intellij_elixir
+end
+
+environment :prod do
+  set include_erts: true
+  set include_src: false
+  set cookie: :intellij_elixir
+end
+
+# You may define one or more releases in this file.
+# If you have not set a default release, or selected one
+# when running `mix release`, the first release in the file
+# will be used by default
+
+release :intellij_elixir do
+  set version: current_version(:intellij_elixir)
+end
+

--- a/rel/config.exs
+++ b/rel/config.exs
@@ -40,5 +40,8 @@ end
 
 release :intellij_elixir do
   set version: current_version(:intellij_elixir)
+  set applications: [
+    :runtime_tools
+  ]
 end
 


### PR DESCRIPTION
# Changelog
## Enhancements
* Switch from `exrm` to `distillery` adds support for Elixir 1.5.
* Add `credo`
  * Run `credo` checks on CodeClimate.
* Add `dialyxir`
  * Run `dialyxir` on Travis CI.
* Build matrix for Elixir 1.3 - 1.5.

## Incompatible Changes
* Switch from `exrm` to `distillery` drops support for Elixir < 1.3.